### PR TITLE
Custom avatar for members in contributors page

### DIFF
--- a/src/pages/contributors/index.js
+++ b/src/pages/contributors/index.js
@@ -6,6 +6,7 @@ import ExternalLink from '../../components/ExternalLink.js';
 import Loader from '../../components/Loader';
 import './index.css';
 import blockedUsers from './blockedUsers.json';
+import members from './members.json';
 
 class ContributorsPage extends React.Component {
   constructor(props) {
@@ -129,7 +130,7 @@ class ContributorsPage extends React.Component {
                     <ExternalLink to={ `https://github.com/${user}` }>
                       <div className='image'>
                         <img
-                          src={ `https://github.com/${user}.png?v=${Math.random()}` }
+                          src={ Object.keys(members).includes(user) ? members[user].avatar : `https://github.com/${user}.png?v=${Math.random()}` }
                           alt='User Avatar'
                           height='150'
                           width='150'

--- a/src/pages/contributors/members.json
+++ b/src/pages/contributors/members.json
@@ -1,5 +1,5 @@
 {
   "Midni8": {
-    "avatar": "https://i.imgur.com/jN2Q5RZ.png"
+    "avatar": "https://i.imgur.com/Ayd3oWX.gif"
   }
 }

--- a/src/pages/contributors/members.json
+++ b/src/pages/contributors/members.json
@@ -1,5 +1,5 @@
 {
   "Midni8": {
-    "avatar": "https://i.imgur.com/hNEyx4Z.png"
+    "avatar": "https://i.imgur.com/jN2Q5RZ.png"
   }
 }

--- a/src/pages/contributors/members.json
+++ b/src/pages/contributors/members.json
@@ -1,0 +1,5 @@
+{
+  "Midni8": {
+    "avatar": "https://i.imgur.com/hNEyx4Z.png"
+  }
+}


### PR DESCRIPTION
Any member in the contributors page can have custom if they want by adding a link to their custom avatar in members.json file. But this should only be limited to the github org. members.